### PR TITLE
Support for manually adding items to the sitemap

### DIFF
--- a/src/Http/Controllers/AltSitemapController.php
+++ b/src/Http/Controllers/AltSitemapController.php
@@ -4,9 +4,15 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Response;
 use Statamic\Facades\Entry;
 use AltDesign\AltSitemap\Helpers\Data;
+use Carbon\Carbon;
 
 class AltSitemapController
 {
+    /**
+     * @var array
+     */
+    private $manualItems = [];
+
     public function index()
     {
         $data = new Data('settings');
@@ -33,6 +39,28 @@ class AltSitemapController
         $data->setAll($fields->process()->values()->toArray());
 
         return true;
+    }
+
+    /**
+     * Add an explicit item to the sitemap.
+     *
+     * @param  array  $item
+     *
+     * @return void
+     */
+    public function registerItem(array $item) {
+        $this->manualItems[] = $item;
+    }
+
+    /**
+     * @param  array  $items
+     *
+     * @return void
+     */
+    public function registerItems(array $items) {
+        foreach ($items as $item) {
+            $this->registerItem($item);
+        }
     }
 
     public function generateSitemap(Request $request)
@@ -84,6 +112,16 @@ class AltSitemapController
             // override with priority from entry if set
             $priority = $entry->sitemap_priority ?? $priority;
             $items[] = array($entry->url, $entry->lastModified()->format('Y-m-d\TH:i:sP'), $priority);
+        }
+
+        foreach ($this->manualItems as $manualItem) {
+            $url = $manualItem[0] ?? null;
+            if (empty($url)) {
+                continue;
+            }
+            $lastModified = $manualItem[1] ?? \Carbon\Carbon::now();
+            $priority = $manualItem[2] ?? 0.5;
+            $items[] = [$url, $lastModified, $priority];
         }
 
         $xml = '<?xml version="1.0" encoding="UTF-8"?>';

--- a/src/Http/Controllers/AltSitemapController.php
+++ b/src/Http/Controllers/AltSitemapController.php
@@ -119,7 +119,7 @@ class AltSitemapController
             if (empty($url)) {
                 continue;
             }
-            $lastModified = $manualItem[1] ?? \Carbon\Carbon::now();
+            $lastModified = $manualItem[1]->format('c') ?? \Carbon\Carbon::now()->format('c');
             $priority = $manualItem[2] ?? 0.5;
             $items[] = [$url, $lastModified, $priority];
         }


### PR DESCRIPTION
This change allows sites to add a single, or mulitple items to the sitemap, using code similar to the following in a service provider's boot() method:

# Using registerItem() to register a single item.
```php
$this->callAfterResolving(
    AltSitemapController::class,
    function ($altSitemapController) {
        $altSitemapController->registerItem(
            [
                '/url-1',
            ]
        );
    }
);
```

# Using registerItems() to register multiple items at once.
```php
$this->callAfterResolving(
     AltSitemapController::class,
     function ($altSitemapController) {
         $altSitemapController->registerItems(
             [
                 [
                     '/url-1',
                 ],
                 [
                     '/url-2',
                     Carbon::create(2024,10,23,12,20,0, 'UTC'),
                 ],
                 [
                     '/url-3',
                     Carbon::create(2024,10,23,12,20,0, 'UTC'),
                     0.8
                 ],
             ]
         );
     }
 );
```

The items passed in must have a URL as a minimum. If no Carbon instance is provided as the second argument, then the time in the timestamp will be set as the current time when the sitemap is accessed. If no priority is provided as the third argument, then a default priority of 0.5 will be assigned. 

