### PR TITLE
Taxonomy support (for discussion)

### DIFF
--- a/resources/blueprints/settings.yaml
+++ b/resources/blueprints/settings.yaml
@@ -61,3 +61,59 @@ tabs:
             field:
               type: collections
               display: 'Exclude Collections from Sitemap'
+          -
+            handle: default_taxonomy_priorities
+            field:
+              collapse: false
+              previews: true
+              fullscreen: true
+              sets:
+                new_set_group:
+                  display: 'New Set Group'
+                  instructions: null
+                  icon: null
+                  sets:
+                    taxonomy_priority:
+                      display: 'Taxonomy Priority'
+                      instructions: null
+                      icon: null
+                      fields:
+                        -
+                          handle: taxonomy
+                          field:
+                            max_items: 1
+                            mode: select
+                            type: taxonomies
+                            display: Taxonomy
+                            icon: taxonomies
+                            listable: hidden
+                            instructions_position: above
+                            visibility: visible
+                            replicator_preview: true
+                            hide_display: false
+                        -
+                          handle: priority
+                          field:
+                            type: float
+                            display: Priority
+                            instructions: 'From 0.0 (lowest priority) to 1.0 (highest priority)'
+                            listable: hidden
+                            instructions_position: above
+                            visibility: visible
+                            replicator_preview: true
+                            hide_display: false
+              type: replicator
+              display: 'Default taxonomy priorities'
+              icon: replicator
+              instructions: 'Select a taxonomy and add a default sitemap priority for all terms in the taxonomy.'
+              listable: hidden
+              instructions_position: above
+              visibility: visible
+              replicator_preview: true
+              hide_display: false
+          -
+            handle: exclude_taxonomies_from_sitemap
+            field:
+              mode: select
+              type: taxonomies
+              display: 'Exclude Taxonomies from Sitemap'

--- a/src/Http/Controllers/AltSitemapController.php
+++ b/src/Http/Controllers/AltSitemapController.php
@@ -5,6 +5,9 @@ use Illuminate\Support\Facades\Response;
 use Statamic\Facades\Entry;
 use AltDesign\AltSitemap\Helpers\Data;
 use Carbon\Carbon;
+use Statamic\Facades\Term;
+use function in_array;
+use function url;
 
 class AltSitemapController
 {
@@ -12,6 +15,15 @@ class AltSitemapController
      * @var array
      */
     private $manualItems = [];
+
+    /**
+     * @var string
+     */
+    private $site_url = '';
+
+    public function __construct() {
+        $this->site_url = url('');
+    }
 
     public function index()
     {
@@ -69,51 +81,108 @@ class AltSitemapController
         $data = new Data('settings');
         $blueprint = $data->getBlueprint(true);
         $fields = $blueprint->fields()->addValues($data->all())->preProcess();
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>';
+        $xml .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+        $xml .= $this->generateEntries($fields);
+        $xml .= $this->generateTaxonomies($fields);
+        $xml .= $this->generateManualItems();
+        $xml .= '</urlset>';
+
+        return Response::make($xml, 200, ['Content-Type' => 'application/xml']);
+    }
+
+    private function generateEntries($fields) {
         $defaultCollectionPriorities = $fields->values()->toArray()['default_collection_priorities'];
         $excludeCollectionFromSitemap = $fields->values()->toArray()['exclude_collections_from_sitemap'];
 
         foreach ($defaultCollectionPriorities as $value) {
-            $collection = $value['collection'][0];
-            $priority = $value['priority'];
-            $settings[] = array($collection, $priority) ;
+            $settings[ $value['collection'][0] ] = $value['priority'];
         }
 
-        $site_url = url('');
         $entries = Entry::all();
+        $items = [];
         foreach ($entries as $entry) {
             // Skip if the entry is not published
             if (!$entry->published()) {
                 continue;
             }
 
-            // skip if to be excluded
+            // Skip if to be excluded
             if ($entry->exclude_from_sitemap == true) {
                 continue;
             }
 
-            // skip if collection is to be excluded
+            // Skip if collection is to be excluded
             if (in_array($entry->collection->handle, $excludeCollectionFromSitemap)) {
                 continue;
             }
 
-            // if the collection has no route setup, skip
+            // If the collection has no route setup, skip
             if ($entry->url() === null) {
                 continue;
             }
 
-            //check if entry collection matches setting[0], if so apply setting[1] as priority
-            $priority = 0.5;
-            $entryCollection = $entry->collection->handle;
-            foreach ($settings ?? [] as $setting) {
-                if ($entryCollection == $setting[0]) {
-                    $priority = $setting[1];
-                }
-            }
-            // override with priority from entry if set
+            // Check if entry collection matches setting[0], if so apply setting[1] as priority
+            $priority = $settings[ $entry->collection->handle ] ?? 0.5;
+
+            // Override with priority from entry if set
             $priority = $entry->sitemap_priority ?? $priority;
             $items[] = array($entry->url, $entry->lastModified()->format('Y-m-d\TH:i:sP'), $priority);
         }
 
+        return $this->generateXmlFragments($items);
+    }
+
+    /**
+     * @param $fields
+     *
+     * @return string
+     */
+    private function generateTaxonomies($fields): string {
+        $defaultTaxonomyPriorities = $fields->values()->toArray()['default_taxonomy_priorities'];
+        $excludeTaxonomiesFromSitemap = $fields->values()->toArray()['exclude_taxonomies_from_sitemap'];
+
+        foreach ($defaultTaxonomyPriorities as $value) {
+            $taxonomy = $value['taxonomy'][0];
+            $priority = $value['priority'];
+            $settings[$taxonomy] = $priority ;
+        }
+
+        $terms = Term::all();
+        $items = [];
+        foreach ($terms as $term) {
+            // Skip if to be excluded
+            //            if ($term->exclude_from_sitemap == true) { // FIXME
+            //                continue;
+            //            }
+
+            // Skip if taxonomy is to be excluded
+            if (in_array($term->taxonomy->handle, $excludeTaxonomiesFromSitemap)) {
+                continue;
+            }
+
+            // If the taxonomy has route, skip
+            if ($term->url() === null) {
+                continue;
+            }
+
+            // Calculate priority.
+            $priority = $settings[$term->taxonomy->handle] ?? 0.5;
+
+            // Override with priority from entry if set
+            //            $priority = $term->sitemap_priority ?? $priority; // FIXME
+            $items[] = array($term->url, $term->lastModified()->format('Y-m-d\TH:i:sP'), $priority);
+        }
+
+        return $this->generateXmlFragments($items);
+    }
+
+    /**
+     * @return string
+     */
+    private function generateManualItems(): string {
+        $items = [];
         foreach ($this->manualItems as $manualItem) {
             $url = $manualItem[0] ?? null;
             if (empty($url)) {
@@ -123,13 +192,21 @@ class AltSitemapController
             $priority = $manualItem[2] ?? 0.5;
             $items[] = [$url, $lastModified, $priority];
         }
+        
+        return $this->generateXmlFragments($items);
+    }
 
-        $xml = '<?xml version="1.0" encoding="UTF-8"?>';
-        $xml .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+    /**
+     * @param array $items
+     *
+     * @return string
+     */
+    private function generateXmlFragments($items): string {
+        $fragment = '';
         foreach ($items as $item) {
-            $xml .='<url><loc>'.$site_url.$item[0].'</loc><lastmod>'.$item[1].'</lastmod><priority>'.$item[2].'</priority></url>';
+            $fragment .='<url><loc>'.$this->site_url.$item[0].'</loc><lastmod>'.$item[1].'</lastmod><priority>'.$item[2].'</priority></url>';
         }
-        $xml .= '</urlset>';
-        return Response::make($xml, 200, ['Content-Type' => 'application/xml']);
+
+        return $fragment;
     }
 }

--- a/src/Http/Controllers/AltSitemapController.php
+++ b/src/Http/Controllers/AltSitemapController.php
@@ -4,9 +4,15 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Response;
 use Statamic\Facades\Entry;
 use AltDesign\AltSitemap\Helpers\Data;
+use Carbon\Carbon;
 
 class AltSitemapController
 {
+    /**
+     * @var array
+     */
+    private $manualItems = [];
+
     public function index()
     {
         $data = new Data('settings');
@@ -33,6 +39,28 @@ class AltSitemapController
         $data->setAll($fields->process()->values()->toArray());
 
         return true;
+    }
+
+    /**
+     * Add an explicit item to the sitemap.
+     *
+     * @param  array  $item
+     *
+     * @return void
+     */
+    public function registerItem(array $item) {
+        $this->manualItems[] = $item;
+    }
+
+    /**
+     * @param  array  $items
+     *
+     * @return void
+     */
+    public function registerItems(array $items) {
+        foreach ($items as $item) {
+            $this->registerItem($item);
+        }
     }
 
     public function generateSitemap(Request $request)
@@ -84,6 +112,16 @@ class AltSitemapController
             // override with priority from entry if set
             $priority = $entry->sitemap_priority ?? $priority;
             $items[] = array($entry->url, $entry->lastModified()->format('Y-m-d\TH:i:sP'), $priority);
+        }
+
+        foreach ($this->manualItems as $manualItem) {
+            $url = $manualItem[0] ?? null;
+            if (empty($url)) {
+                continue;
+            }
+            $lastModified = $manualItem[1] ?? \Carbon\Carbon::now();
+            $priority = $manualItem[2] ?? 0.5;
+            $items[] = [$url, $lastModified, $priority];
         }
 
         $xml = '<?xml version="1.0" encoding="UTF-8"?>';


### PR DESCRIPTION
This is an initial stab at taxonomy support (as requested in #7)

This PR:
1. Adds two sections to the sitemap settings to allow you to choose priorities for specific taxonomies and whether to exclude certain taxonomies from the sitemap
2. Refactors the code in generateSitemap() a little to break into logical sections for Entries, Terms, and manually added URLs (a further development from #8 - this can supercede that if you think this can be accepted). 
3. Generates entries in the sitemap for taxonomy terms

It does not:
1. Add entries in the sitemap for taxonomy "listing" pages - ie a page which lists all terms in a given taxonomy
2. Correctly calculate lastModified() dates (IMHO). The date is the date on which the term itself was last updated, and should probably more accurately be the date of most recently modified entry associated with that term?
3. Allow individual tags to be excluded from the sitemap - or have their priorities set - see FIXMEs left in the code

On [3] if someone can provide a pointer as to how the Alt-Sitemap blueprint is auto-assigned to entries I can look at expanding this PR to also do that on term edit pages.