### PR TITLE
Correctly initialise settings in flat file sitemap generation

### DIFF
--- a/src/Http/Controllers/AltSitemapController.php
+++ b/src/Http/Controllers/AltSitemapController.php
@@ -216,6 +216,21 @@ class AltSitemapController
         $excludeTaxonomiesFromSitemap = $fields->values()->toArray()['exclude_taxonomies_from_sitemap'];
         $excludeCollectionFromSitemap = $fields->values()->toArray()['exclude_collections_from_sitemap'];
 
+        $defaultCollectionPriorities = $fields->values()->toArray()['default_collection_priorities'];
+        $defaultTaxonomyPriorities = $fields->values()->toArray()['default_taxonomy_priorities'];
+
+        foreach ($defaultCollectionPriorities as $value) {
+            $collection = $value['collection'][0];
+            $priority = $value['priority'];
+            $settings[] = [$collection, $priority];
+        }
+
+        foreach ($defaultTaxonomyPriorities as $value) {
+            $taxonomy = $value['taxonomy'][0];
+            $priority = $value['priority'];
+            $settings[] = [$taxonomy, $priority];
+        }
+
         $site_url = url('');
         $entries = $this->getFlatFileEntries();
 


### PR DESCRIPTION
Ideally there would be some de-duplication of code between the two generation methods (flat file vs eloquent), but this PR copies across some missing initialisation from the eloquent method into the flat file one to fix #13 

