### PR TITLE
🩹 fix: cast priority value to a float instead

### DIFF
--- a/src/Http/Controllers/AltSitemapController.php
+++ b/src/Http/Controllers/AltSitemapController.php
@@ -362,7 +362,7 @@ class AltSitemapController
                 'id' => $entry->id,
                 'uri' => $entry->uri,
                 'title' => $entry->title,
-                'sitemap_priority' => (int) $entry->sitemap_priority,
+                'sitemap_priority' => (float) $entry->sitemap_priority,
                 'exclude_from_sitemap' => $entry->exclude_from_sitemap === 'true',
                 'published' => (bool) $entry->published,
                 'collection' => $entry->collection,


### PR DESCRIPTION
This pr fixes the code that casts the priority value to an integer.

See issue #20 for more info